### PR TITLE
Add search result coloring for items rarity > 4

### DIFF
--- a/Auctionator/AuctionatorScan.lua
+++ b/Auctionator/AuctionatorScan.lua
@@ -168,12 +168,7 @@ function AtrScan:UpdateItemLink (itemLink)
 		self.itemClass		= Atr_ItemType2AuctionClass (sType);
 		self.itemSubclass	= Atr_SubType2AuctionSubclass (self.itemClass, sSubType);	
 
-		self.itemTextColor = { 1.0, 1.0, 1.0 };
-
-		if (quality == 0)	then	self.itemTextColor = { 0.6, 0.6, 0.6 };	end
-		if (quality == 2)	then	self.itemTextColor = { 0.2, 1.0, 0.0 };	end
-		if (quality == 3)	then	self.itemTextColor = { 0.0, 0.5, 1.0 };	end
-		if (quality == 4)	then	self.itemTextColor = { 0.7, 0.3, 1.0 };	end
+		self.itemTextColor = ITEM_QUALITY_COLORS[quality]
 	end
 
 end


### PR DESCRIPTION
Colors search results to match their rarity.  In game tooltips has heirloom and vanity rarity the same color, I've elected to follow the color guide from https://wowpedia.fandom.com/wiki/Quality

![Screenshot 2022-12-05 133338](https://user-images.githubusercontent.com/119889093/205747152-47c6431c-8054-4ac3-9493-cf73f9a90004.png)

The extra ||| at the starts of the lines are apparently from my font choice (calibri), not from this change.