### PR TITLE
Version bump to higher than 4.0.1 client versions but lower than legi…

### DIFF
--- a/Auctionator/Auctionator.toc
+++ b/Auctionator/Auctionator.toc
@@ -1,6 +1,6 @@
 ## Interface: 30300
 ## Title: Auctionator
-## Version: 2.6.3
+## Version: 2.9.9
 ## Author: Zirco
 ## Dependencies: Auctionator_Pricing_History, Auctionator_Price_Database
 ## X-Website: http://auctionator-addon.com
@@ -36,4 +36,3 @@ AuctionatorConfig.lua
 AuctionatorBuy.lua
 
 AuctionatorConfig.xml
-


### PR DESCRIPTION
…on/etc versions

Legacy-wow version is 2.6.8

This addresses people using the launcher version and being told there is an update available because someone is using the cata version of the addon that has not been tailored for ascension.